### PR TITLE
CI: Testing new configurations for `release-drafter`

### DIFF
--- a/.github/release-drafter-helm.yml
+++ b/.github/release-drafter-helm.yml
@@ -1,7 +1,7 @@
 name-template: "chart-$RESOLVED_VERSION"
 tag-template: "chart-$RESOLVED_VERSION"
 include-labels:
-  - "helm-chart"
+  - helm-chart
 tag-prefix: "chart-"
 categories:
   - title: Breaking Changes 💥

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,6 +2,7 @@ name-template: "$RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
 exclude-labels:
   - helm-chart
+tag-prefix: ""
 categories:
   - title: Breaking Changes 💥
     labels:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [X] Other (please describe): CI

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, running the `release-drafter-helm` action will create a draft release with all PRs labelled `helm-chart`. The release will be prefixed with `chart-`.
If you run the action `release-drafter` afterwards, it will overwrite the first one and also create a new draft release. So now there will be two identical drafts.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Hopefully, this will make the action run parallel and have one draft release for the application and one draft release for the chart.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

None.