### PR TITLE
CI: Fix so build container image only runs on application release + Pointing chart releaser to the correct folder

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -1,8 +1,9 @@
 name: Build image and push to GHCR
 
 on:
-  release:
-    types: [published]
+  push:
+    tags-ignore:
+      - 'chart-*'
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -24,3 +24,5 @@ jobs:
         uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          charts_dir: chart


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [X] Other (please describe): CI

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

1. Container builder action runs every release.
2. Chart releaser looks in the wrong folder.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Container builder action now only runs when a tag is pushed that doesn't prefix with `chart-`.
- Chart releaser now looks in folder `chart` instead of `charts`.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

None.