### PR TITLE
bug: Log presented wrong unit

### DIFF
--- a/pkg/k8s/ScaleNamespaceUp.go
+++ b/pkg/k8s/ScaleNamespaceUp.go
@@ -9,13 +9,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func ScaleNamespaceUp(namespace string, additionalHours time.Duration) {
+func ScaleNamespaceUp(namespace string, additionalTime time.Duration) {
 	c := client()
 
 	// Create timestamps for annotations
 	t := time.Now()
 	now := t.Format("2006-01-02T15:04:05+00:00")
-	end := t.Add(additionalHours).Format("2006-01-02T15:04:05+00:00")
+	end := t.Add(additionalTime).Format("2006-01-02T15:04:05+00:00")
 	timeString := fmt.Sprintf("%s-%s", now, end)
 
 	if config.Config.Debug {
@@ -37,5 +37,5 @@ func ScaleNamespaceUp(namespace string, additionalHours time.Duration) {
 		panic(err.Error())
 	}
 
-	fmt.Printf("[INFO]: Namespace %s is now up for %d hours\n", namespace, additionalHours)
+	fmt.Printf("[INFO]: Namespace %s is now up for %v hours\n", namespace, additionalTime.Hours())
 }

--- a/pkg/pubsub/Listen.go
+++ b/pkg/pubsub/Listen.go
@@ -29,7 +29,7 @@ func Listen() error {
 	// Receive messages
 	err = subscription.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 		if config.Config.Debug {
-			fmt.Printf("[DEBUG]: Received message: %s", string(msg.Data))
+			fmt.Printf("[DEBUG]: Received message: %s\n", string(msg.Data))
 		}
 
 		// Unmarshal message

--- a/pkg/pubsub/Listen.go
+++ b/pkg/pubsub/Listen.go
@@ -41,14 +41,14 @@ func Listen() error {
 		if m.Action == "kscale_scale_namespace_up" {
 			fmt.Printf("[INFO]: Scaling %s namespace %s up\n", m.Cluster, m.Namespace)
 			convertIntToTimeDuration, err := time.ParseDuration(fmt.Sprintf("%dh", m.Duration))
+			if err != nil {
+				panic(err)
+			}
 
 			if config.Config.Debug {
 				fmt.Printf("[DEBUG]: Duration: %d, Duration in time.Duration: %s\n", m.Duration, convertIntToTimeDuration)
 			}
 
-			if err != nil {
-				panic(err)
-			}
 			k8s.ScaleNamespaceUp(m.Namespace, convertIntToTimeDuration)
 		}
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

This has to do with #16 where duration is wrongly parsed. In the log, the wrong unit was passed.

Issue Number: #16 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- This corrects the log with the correct unit (hours).
- This adds a newline to one log line that missed it.
- This changes one of the variable names in `ScaleNamespaceUp`.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

None.