### PR TITLE
Feat: Google Instance Metadata to get cluster name

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,11 +4,12 @@ import (
 	"log"
 
 	"github.com/kelseyhightower/envconfig"
+	"github.com/orkarstoft/kscale/pkg/instancemetadata"
 )
 
 type config struct {
 	ProjectID   string `envconfig:"PROJECT_ID" required:"true"`
-	ClusterName string `envconfig:"CLUSTERNAME" required:"true"`
+	ClusterName string `envconfig:"CLUSTERNAME" required:"false"`
 	Topic       string `envconfig:"TOPIC" required:"true"`
 	Debug       bool   `envconfig:"DEBUG" default:"false"`
 }
@@ -19,5 +20,17 @@ func Init() {
 	err := envconfig.Process("KSCALE", &Config)
 	if err != nil {
 		log.Fatal(err.Error())
+	}
+
+	if Config.ProjectID == "" || Config.Topic == "" {
+		log.Fatal("Missing required env variables")
+	}
+
+	if Config.ClusterName == "" {
+		clustername, err := instancemetadata.GetGCPInstanceMetadata()
+		if err != nil {
+			log.Fatalf("Failed to get cluster name from GCP Instance Metadata: %v", err)
+		}
+		Config.ClusterName = clustername
 	}
 }

--- a/pkg/instancemetadata/GetGCPInstanceMetadata.go
+++ b/pkg/instancemetadata/GetGCPInstanceMetadata.go
@@ -1,0 +1,32 @@
+package instancemetadata
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func GetGCPInstanceMetadata() (string, error) {
+	req, err := http.NewRequest("GET", "http://metadata/computeMetadata/v1/instance/attributes/cluster-name", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %v", err)
+	}
+
+	req.Header.Add("Metadata-Flavor", "Google")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to get metadata: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get metadata: %v", resp.Status)
+	}
+
+	respData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %v", err)
+	}
+
+	return string(respData), nil
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If the cluster name isn't specified, it will just use blank. Read #25.

Issue Number: Resolves #26 
Also resolves #25 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

If cluster name environment variable isn't set, it will try to get it from Google Instance Metadata service.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

It would be nice it implement AWS and Azure as well.