### PR TITLE
Feat: Reuse subscription and enable scaling

### DIFF
--- a/pkg/pubsub/createSubscription.go
+++ b/pkg/pubsub/createSubscription.go
@@ -9,19 +9,18 @@ import (
 	"github.com/orkarstoft/kscale/pkg/config"
 )
 
-func createSubscription(ctx context.Context, client *pubsub.Client) (pubsub.Subscription, error) {
+func createSubscription(ctx context.Context, client *pubsub.Client, subName string) (*pubsub.Subscription, error) {
 	// Create subscription
-	subName := fmt.Sprintf("kscale-%s", config.Config.ClusterName)
 	subscription, err := client.CreateSubscription(ctx, subName, pubsub.SubscriptionConfig{
 		Topic:       client.Topic(config.Config.Topic),
 		Filter:      "attributes.cluster = \"" + config.Config.ClusterName + "\"",
 		AckDeadline: 10 * time.Second,
 	})
 	if err != nil {
-		return pubsub.Subscription{}, fmt.Errorf("pubsub.CreateSubscription error: %v", err)
+		return &pubsub.Subscription{}, fmt.Errorf("pubsub.CreateSubscription error: %v", err)
 	}
 
 	fmt.Printf("[INFO]: Subscription %s created to topic %s with attribute filter \"attributes.cluster = %s\"\n", subName, config.Config.Topic, config.Config.ClusterName)
 
-	return *subscription, nil
+	return subscription, nil
 }

--- a/pkg/pubsub/createSubscription.go
+++ b/pkg/pubsub/createSubscription.go
@@ -7,12 +7,11 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"github.com/orkarstoft/kscale/pkg/config"
-	"github.com/orkarstoft/kscale/pkg/random"
 )
 
 func createSubscription(ctx context.Context, client *pubsub.Client) (pubsub.Subscription, error) {
 	// Create subscription
-	subName := fmt.Sprintf("kscale-%s-%s", config.Config.ClusterName, random.String(5))
+	subName := fmt.Sprintf("kscale-%s", config.Config.ClusterName)
 	subscription, err := client.CreateSubscription(ctx, subName, pubsub.SubscriptionConfig{
 		Topic:       client.Topic(config.Config.Topic),
 		Filter:      "attributes.cluster = \"" + config.Config.ClusterName + "\"",


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the application creates a subscription with the format `kscale-{{clustername}}-{{5 random chars}}`. If we remove the last `{{5 random chars}}`, then we'll be able to scale the application in the cluster and only process messages related to that cluster once.

If scaling the application as it is right now, there will be two subscriptions with the same attributes, so any message to the topic matching those attributes will be sent to both subscriptions. Then both instances of the application will process that message and do what it's supposed to.

Issue Number: Resolves #28 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The application will try to use an existing subscription. If it doesn't exist, it will create it.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

None.