### PR TITLE
Feat: Added timezones to config to improve time string control

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.20-alpine AS builder
 
 ARG UPX_VERSION=4.0.2-r0
 
-RUN apk update && apk add --no-cache ca-certificates upx=$UPX_VERSION && update-ca-certificates
+RUN apk update && apk add --no-cache ca-certificates upx=$UPX_VERSION tzdata && update-ca-certificates
 
 WORKDIR /app
 
@@ -28,6 +28,7 @@ FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder --chown=kscale:kscale /app/kscale /app/kscale
 
 USER kscale:kscale

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ func main() {
 
 	fmt.Println("[INFO]: Starting KScale")
 	fmt.Printf("[INFO]: Creating subscriber for topic %s in project %s\n", config.Config.Topic, config.Config.ProjectID)
+
 	err := pubsub.Listen()
 	if err != nil {
 		fmt.Printf("Error: %s", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 
 type config struct {
 	ProjectID   string `envconfig:"PROJECT_ID" required:"true"`
+	TimeZone    string `envconfig:"TIMEZONE" default:"Europe/Copenhagen"`
 	ClusterName string `envconfig:"CLUSTERNAME" required:"false"`
 	Topic       string `envconfig:"TOPIC" required:"true"`
 	Debug       bool   `envconfig:"DEBUG" default:"false"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/kelseyhightower/envconfig"
@@ -25,6 +26,10 @@ func Init() {
 
 	if Config.ProjectID == "" || Config.Topic == "" {
 		log.Fatal("Missing required env variables")
+	}
+
+	if Config.Debug {
+		fmt.Printf("[DEBUG]: Config is: %+v\n", Config)
 	}
 
 	if Config.ClusterName == "" {

--- a/pkg/k8s/ScaleNamespaceUp.go
+++ b/pkg/k8s/ScaleNamespaceUp.go
@@ -12,8 +12,12 @@ import (
 func ScaleNamespaceUp(namespace string, additionalTime time.Duration) {
 	c := client()
 
-	// Create timestamps for annotations
-	t := time.Now()
+	location, err := time.LoadLocation(config.Config.TimeZone)
+	if err != nil {
+		panic(err)
+	}
+
+	t := time.Now().In(location)
 	now := t.Format("2006-01-02T15:04:05+00:00")
 	end := t.Add(additionalTime).Format("2006-01-02T15:04:05+00:00")
 	timeString := fmt.Sprintf("%s-%s", now, end)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, kscale doesn't take time zones into account. Any time string created will be `+00:00` which is probably never what anyone wants.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- You can now set the environment variable `KSCALE_TIMEZONE` to any timezone from the IANA timezone database.
- If the environment variable isn't set, it will default to `Europe/Copenhagen`.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

None.