### PR TITLE
Bug: Correcting timezone stuff and default to UTC

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 
 type config struct {
 	ProjectID   string `envconfig:"PROJECT_ID" required:"true"`
-	TimeZone    string `envconfig:"TIMEZONE" default:"Europe/Copenhagen"`
+	TimeZone    string `envconfig:"TIMEZONE" default:"UTC"`
 	ClusterName string `envconfig:"CLUSTERNAME" required:"false"`
 	Topic       string `envconfig:"TOPIC" required:"true"`
 	Debug       bool   `envconfig:"DEBUG" default:"false"`

--- a/pkg/k8s/ScaleNamespaceUp.go
+++ b/pkg/k8s/ScaleNamespaceUp.go
@@ -19,8 +19,8 @@ func ScaleNamespaceUp(namespace string, additionalTime time.Duration) {
 	}
 
 	t := time.Now().In(location)
-	now := t.Format("2006-01-02T15:04:05+00:00")
-	end := t.Add(additionalTime).Format("2006-01-02T15:04:05+00:00")
+	now := t.Format("2006-01-02T15:04:05-0700")
+	end := t.Add(additionalTime).Format("2006-01-02T15:04:05-0700")
 	timeString := fmt.Sprintf("%s-%s", now, end)
 
 	logger.Log.Debug().Msgf("timeString is set to: %s", timeString)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Defaulting to `Europe/Copenhagen` made the time string look like `2023-05-31T11:39:05+00:00-2023-05-31T12:39:05+00:00` but should like `2023-05-31T9:39:05+02:00-2023-05-31T10:39:05+02:00`.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- It now defaults to UTC with will work even though the kube-downscaler `uptime` or `downtime` annotation runs in another timezone.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Timezones might be removed in future releases as it's not handled correctly and doesn't give any value to have when kube-downscaler works fine without.