### PR TITLE
Bug: Incorrect time spec value according to kube-downscaler

### DIFF
--- a/pkg/k8s/ScaleNamespaceUp.go
+++ b/pkg/k8s/ScaleNamespaceUp.go
@@ -19,8 +19,8 @@ func ScaleNamespaceUp(namespace string, additionalTime time.Duration) {
 	}
 
 	t := time.Now().In(location)
-	now := t.Format("2006-01-02T15:04:05-0700")
-	end := t.Add(additionalTime).Format("2006-01-02T15:04:05-0700")
+	now := t.Format("2006-01-02T15:04:05-07:00")
+	end := t.Add(additionalTime).Format("2006-01-02T15:04:05-07:00")
 	timeString := fmt.Sprintf("%s-%s", now, end)
 
 	logger.Log.Debug().Msgf("timeString is set to: %s", timeString)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The time spec fix from #43 is missing a colon to comply with kube-downscaler time spec.
Currently, the actual time spec being annotated is `2023-06-13T19:11:51+0000-2023-06-13T20:11:51+0000` and should be `2023-06-13T19:11:51+00:00-2023-06-13T20:11:51+00:00`.

Error from the pod:
```ERROR: Failed to autoscale: Time spec value "2023-06-13T19:11:51+0000-2023-06-13T20:11:51+0000" does not match format ("Mon-Fri 06:30-20:30 Europe/Berlin" or "2019-01-01T00:00:00+00:00-2019-01-02T12:34:56+00:00")```

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The annotation now follows kube-downscaler time spec `2023-06-13T19:11:51+00:00-2023-06-13T20:11:51+00:00`.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->